### PR TITLE
GC3-22: Create bubbles

### DIFF
--- a/floatable.tscn
+++ b/floatable.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://d21so7t4ukwd8"]
+
+[ext_resource type="Script" uid="uid://1d5embmivbcp" path="res://objects/floatable.gd" id="1_7w4rx"]
+
+[node name="Floatable" type="Node"]
+script = ExtResource("1_7w4rx")

--- a/objects/bubbles.gd
+++ b/objects/bubbles.gd
@@ -26,6 +26,7 @@ func _ready() -> void:
 	timer.one_shot = true
 	timer.timeout.connect(_on_timeout)
 	set_deferred("monitorable", is_active)
+	set_deferred("monitoring", is_active)
 	hide()
 
 func start() -> void:
@@ -33,12 +34,14 @@ func start() -> void:
 	is_active = true
 	_animation_player.play("idle")
 	set_deferred("monitorable", is_active)
+	set_deferred("monitoring", is_active)
 	show()
 	timer.start(get_start_time())
 
 func switch_active() -> void:
 	is_active = !is_active
 	set_deferred("monitorable", is_active)
+	set_deferred("monitoring", is_active)
 	if is_active:
 		show()
 	else:

--- a/objects/bubbles.gd
+++ b/objects/bubbles.gd
@@ -1,0 +1,72 @@
+class_name Bubbles extends Area2D
+
+@onready var move_controller: MoveController = $MoveController
+@onready var _animation_player: AnimationPlayer = $AnimationPlayer
+@onready var timer: Timer = $Timer
+
+@export var should_move_left: bool = true
+@export_range(0, 10) var move_interval: float = 1
+
+var move_direction: Vector2 = Vector2.ZERO
+var is_started: bool = false
+var is_active: bool = false
+
+# Timer for how long bubble should be underwater and above water
+var timer_duration: float = 0
+var min_inactive_time: float = 2.0
+var max_inactive_time: float = 4.0
+
+var min_active_time: float = 3.0
+var max_active_time: float = 8.0
+
+func _ready() -> void:
+	move_controller.move_interval = move_interval
+	move_direction = Vector2.LEFT if should_move_left else Vector2.RIGHT
+	move_controller.moved.connect(_on_move)
+	timer.one_shot = true
+	timer.timeout.connect(_on_timeout)
+	set_deferred("monitorable", is_active)
+	hide()
+
+func start() -> void:
+	is_started = true
+	is_active = true
+	_animation_player.play("idle")
+	set_deferred("monitorable", is_active)
+	show()
+	timer.start(get_start_time())
+
+func switch_active() -> void:
+	is_active = !is_active
+	set_deferred("monitorable", is_active)
+	if is_active:
+		show()
+	else:
+		hide()
+
+func _process(delta: float) -> void:
+	if is_started:
+		update()
+		move_controller.update()
+
+func update() -> void:
+	move_controller.move(move_direction)
+
+func _on_move() -> void:
+	if not is_active:
+		return
+	var colliding_areas: Array[Area2D] = get_overlapping_areas()
+	for area in colliding_areas:
+		if area is Player and area.move_controller.is_finished_moving():
+			area.move_controller.shift(move_direction)
+
+func get_start_time() -> float:
+	if is_active:
+		return randf_range(min_active_time, max_active_time)
+	return randf_range(min_inactive_time, max_inactive_time)
+
+func _on_timeout() -> void:
+	# TODO: Later replace this with starting an animation, and on that animation end,
+	# Perform the switch and restart the timer (bubble pop or reappear animation)
+	switch_active()
+	timer.start(get_start_time())

--- a/objects/bubbles.gd.uid
+++ b/objects/bubbles.gd.uid
@@ -1,0 +1,1 @@
+uid://fpw7jqiowvha

--- a/objects/bubbles.tscn
+++ b/objects/bubbles.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=3 uid="uid://obli20lme1fv"]
+[gd_scene load_steps=10 format=3 uid="uid://obli20lme1fv"]
 
 [ext_resource type="Script" uid="uid://fpw7jqiowvha" path="res://objects/bubbles.gd" id="1_spyys"]
 [ext_resource type="Texture2D" uid="uid://6a0x3in374xk" path="res://sprites/sprite_sheets/soap.png" id="2_d38rt"]
 [ext_resource type="PackedScene" uid="uid://dga1ual85j14i" path="res://controllers/move_controller.tscn" id="3_2tobd"]
 [ext_resource type="PackedScene" uid="uid://halaq7co6qj2" path="res://expirable.tscn" id="4_ylg18"]
+[ext_resource type="PackedScene" uid="uid://d21so7t4ukwd8" path="res://floatable.tscn" id="5_d38rt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_24jkt"]
 size = Vector2(63, 31)
@@ -72,3 +73,5 @@ area = NodePath("..")
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
+
+[node name="Floatable" parent="." instance=ExtResource("5_d38rt")]

--- a/objects/bubbles.tscn
+++ b/objects/bubbles.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://bg6em2nd0yegx"]
+[gd_scene load_steps=9 format=3 uid="uid://obli20lme1fv"]
 
-[ext_resource type="Script" uid="uid://dvavld8nx2lny" path="res://objects/soap.gd" id="1_p0is6"]
-[ext_resource type="PackedScene" uid="uid://dga1ual85j14i" path="res://controllers/move_controller.tscn" id="2_0f703"]
-[ext_resource type="Texture2D" uid="uid://6a0x3in374xk" path="res://sprites/sprite_sheets/soap.png" id="2_f44kt"]
-[ext_resource type="PackedScene" uid="uid://halaq7co6qj2" path="res://expirable.tscn" id="4_f44kt"]
+[ext_resource type="Script" uid="uid://fpw7jqiowvha" path="res://objects/bubbles.gd" id="1_spyys"]
+[ext_resource type="Texture2D" uid="uid://6a0x3in374xk" path="res://sprites/sprite_sheets/soap.png" id="2_d38rt"]
+[ext_resource type="PackedScene" uid="uid://dga1ual85j14i" path="res://controllers/move_controller.tscn" id="3_2tobd"]
+[ext_resource type="PackedScene" uid="uid://halaq7co6qj2" path="res://expirable.tscn" id="4_ylg18"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_24jkt"]
 size = Vector2(63, 31)
@@ -47,8 +47,8 @@ _data = {
 &"idle": SubResource("Animation_0f703")
 }
 
-[node name="Soap" type="Area2D"]
-script = ExtResource("1_p0is6")
+[node name="Bubbles" type="Area2D"]
+script = ExtResource("1_spyys")
 move_interval = 0.6
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -56,10 +56,10 @@ shape = SubResource("RectangleShape2D_24jkt")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture_filter = 1
-texture = ExtResource("2_f44kt")
+texture = ExtResource("2_d38rt")
 hframes = 3
 
-[node name="MoveController" parent="." node_paths=PackedStringArray("object") instance=ExtResource("2_0f703")]
+[node name="MoveController" parent="." node_paths=PackedStringArray("object") instance=ExtResource("3_2tobd")]
 object = NodePath("..")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -67,5 +67,8 @@ libraries = {
 &"": SubResource("AnimationLibrary_1s1o8")
 }
 
-[node name="Expirable" parent="." node_paths=PackedStringArray("area") instance=ExtResource("4_f44kt")]
+[node name="Expirable" parent="." node_paths=PackedStringArray("area") instance=ExtResource("4_ylg18")]
 area = NodePath("..")
+
+[node name="Timer" type="Timer" parent="."]
+one_shot = true

--- a/objects/bubbles.tscn
+++ b/objects/bubbles.tscn
@@ -68,10 +68,16 @@ libraries = {
 &"": SubResource("AnimationLibrary_1s1o8")
 }
 
-[node name="Expirable" parent="." node_paths=PackedStringArray("area") instance=ExtResource("4_ylg18")]
-area = NodePath("..")
+[node name="Expirable" parent="." node_paths=PackedStringArray("area", "area_to_expire") instance=ExtResource("4_ylg18")]
+area = NodePath("../ExpiryArea")
+area_to_expire = NodePath("..")
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
 
 [node name="Floatable" parent="." instance=ExtResource("5_d38rt")]
+
+[node name="ExpiryArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="ExpiryArea"]
+shape = SubResource("RectangleShape2D_24jkt")

--- a/objects/expirable.gd
+++ b/objects/expirable.gd
@@ -1,12 +1,15 @@
 class_name Expirable extends Node
 
 @export var area: Area2D
+@export var area_to_expire: Area2D
 
 var should_expire: bool = false
 
 func _ready() -> void:
 	if area:
 		_initialize_area()
+	if area_to_expire == null:
+		area_to_expire = area
 
 func set_area(new_area: Area2D) -> void:
 	if area:
@@ -25,4 +28,4 @@ func _on_enter(entered_area: Area2D) -> void:
 
 func _on_exit(exited_area: Area2D) -> void:
 	if exited_area is PlayArea and should_expire:
-		area.queue_free()
+		area_to_expire.queue_free()

--- a/objects/floatable.gd
+++ b/objects/floatable.gd
@@ -1,0 +1,1 @@
+class_name Floatable extends Node

--- a/objects/floatable.gd.uid
+++ b/objects/floatable.gd.uid
@@ -1,0 +1,1 @@
+uid://1d5embmivbcp

--- a/objects/player.gd
+++ b/objects/player.gd
@@ -40,7 +40,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		move()
 
 func _handle_area_enter(area: Area2D) -> void:
-	if area is Soap or area is Water:
+	if area.has_node("Floatable") or area is Water:
 		areas.append(area)
 	elif area is Person:
 		fail_player()
@@ -48,7 +48,7 @@ func _handle_area_enter(area: Area2D) -> void:
 		_on_player_reached_bed(area)
 
 func _handle_area_exit(area: Area2D) -> void:
-	if area is Soap or area is Water:
+	if area.has_node("Floatable") or area is Water:
 		areas.erase(area)
 		if move_controller.is_finished_moving() and did_fail_by_water():
 			fail_player()
@@ -85,7 +85,7 @@ func did_fail_by_water() -> bool:
 	for area in areas:
 		if area is Water:
 			is_in_water = true
-		elif area is Soap:
+		elif area.has_node("Floatable"):
 			return false
 	return is_in_water
 

--- a/objects/soap.tscn
+++ b/objects/soap.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=3 uid="uid://bg6em2nd0yegx"]
+[gd_scene load_steps=10 format=3 uid="uid://bg6em2nd0yegx"]
 
 [ext_resource type="Script" uid="uid://dvavld8nx2lny" path="res://objects/soap.gd" id="1_p0is6"]
 [ext_resource type="PackedScene" uid="uid://dga1ual85j14i" path="res://controllers/move_controller.tscn" id="2_0f703"]
 [ext_resource type="Texture2D" uid="uid://6a0x3in374xk" path="res://sprites/sprite_sheets/soap.png" id="2_f44kt"]
 [ext_resource type="PackedScene" uid="uid://halaq7co6qj2" path="res://expirable.tscn" id="4_f44kt"]
+[ext_resource type="PackedScene" uid="uid://d21so7t4ukwd8" path="res://floatable.tscn" id="5_1s1o8"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_24jkt"]
 size = Vector2(63, 31)
@@ -69,3 +70,5 @@ libraries = {
 
 [node name="Expirable" parent="." node_paths=PackedStringArray("area") instance=ExtResource("4_f44kt")]
 area = NodePath("..")
+
+[node name="Floatable" parent="." instance=ExtResource("5_1s1o8")]

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://j3ka2q4kgsok"]
+[gd_scene load_steps=15 format=3 uid="uid://j3ka2q4kgsok"]
 
 [ext_resource type="PackedScene" uid="uid://cmrxs55rkgib0" path="res://objects/player.tscn" id="1_ia1lp"]
 [ext_resource type="PackedScene" uid="uid://dk7k5h44nry4" path="res://objects/person.tscn" id="2_sasra"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://cbo65rtkhu5pr" path="res://objects/water.tscn" id="6_7cbxl"]
 [ext_resource type="PackedScene" uid="uid://dtdj5camjcni5" path="res://objects/spawner.tscn" id="6_8pr8v"]
 [ext_resource type="PackedScene" uid="uid://di4c40pm2o71b" path="res://objects/bed.tscn" id="8_buypi"]
+[ext_resource type="PackedScene" uid="uid://obli20lme1fv" path="res://objects/bubbles.tscn" id="8_rpuu0"]
 [ext_resource type="PackedScene" uid="uid://bt1kl17cqxynq" path="res://ui/game_end_menu.tscn" id="9_njel3"]
 [ext_resource type="PackedScene" uid="uid://cqr02dvtuihdd" path="res://ui/lives.tscn" id="10_vr1i5"]
 
@@ -53,8 +54,6 @@ object_parent = NodePath("..")
 object = NodePath("Soap")
 
 [node name="Soap" parent="Spawner" instance=ExtResource("3_sasra")]
-should_move_left = true
-move_interval = 0.6
 
 [node name="Spawner2" parent="." node_paths=PackedStringArray("object_parent", "object") instance=ExtResource("6_8pr8v")]
 position = Vector2(336, -32)
@@ -65,6 +64,14 @@ min_spawn_time = 0.5
 max_spawn_time = 2.0
 
 [node name="Person" parent="Spawner2" instance=ExtResource("2_sasra")]
+
+[node name="Spawner3" parent="." node_paths=PackedStringArray("object_parent", "object") instance=ExtResource("6_8pr8v")]
+position = Vector2(336, -96)
+autostart = true
+object_parent = NodePath("..")
+object = NodePath("Bubbles")
+
+[node name="Bubbles" parent="Spawner3" instance=ExtResource("8_rpuu0")]
 
 [node name="Beds" type="Node" parent="."]
 
@@ -85,7 +92,6 @@ position = Vector2(144, -304)
 [node name="GameEndMenu" parent="CanvasLayer" instance=ExtResource("9_njel3")]
 
 [node name="Lives" parent="CanvasLayer" node_paths=PackedStringArray("life_sprite") instance=ExtResource("10_vr1i5")]
-anchors_preset = 0
 life_sprite = NodePath("Sprite2D")
 
 [node name="Sprite2D" type="Sprite2D" parent="CanvasLayer/Lives"]

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -47,6 +47,18 @@ modulate = Color(0.27117, 0.684052, 0.868411, 1)
 scale = Vector2(640, 32)
 texture = SubResource("CanvasTexture_7cbxl")
 
+[node name="Water2" parent="." instance=ExtResource("6_7cbxl")]
+z_index = -1
+position = Vector2(0, -96)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Water2"]
+shape = SubResource("RectangleShape2D_8pr8v")
+
+[node name="Sprite2D" type="Sprite2D" parent="Water2"]
+modulate = Color(0.27117, 0.684052, 0.868411, 1)
+scale = Vector2(640, 32)
+texture = SubResource("CanvasTexture_7cbxl")
+
 [node name="Spawner" parent="." node_paths=PackedStringArray("object_parent", "object") instance=ExtResource("6_8pr8v")]
 position = Vector2(336, 32)
 autostart = true


### PR DESCRIPTION
Bubbles is like soap but periodically dives in water and pops back up
Changes:
- Created bubbles object
- Created floatable component for floating objects like soap and bubbles, for objects that can prevent the player from losing from water
- Updated expirable component to designate what area to expire on area escaping play area (for bubbles since it switches underwater by disabling monitoring, which triggers exit arena)