### PR TITLE
GC3-42: Update spawner to be better on start

### DIFF
--- a/end_frame.tscn
+++ b/end_frame.tscn
@@ -5,6 +5,21 @@
 [sub_resource type="AtlasTexture" id="AtlasTexture_vydik"]
 region = Rect2(0, 0, 128, 128)
 
+[sub_resource type="Animation" id="Animation_8yi5b"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:texture:region")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(0, 0, 128, 128)]
+}
+
 [sub_resource type="Animation" id="Animation_vydik"]
 resource_name = "frame"
 length = 0.45
@@ -21,21 +36,6 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1e+06, 1e+06, 1e+06),
 "update": 0,
 "values": [Rect2(0, 0, 128, 128), Rect2(128, 0, 128, 128), Rect2(256, 0, 128, 128)]
-}
-
-[sub_resource type="Animation" id="Animation_8yi5b"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:texture:region")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Rect2(0, 0, 128, 128)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_256dw"]

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -101,6 +101,8 @@ autostart = true
 object = NodePath("Soap")
 min_spawn_time = 2.0
 move_interval = 0.8
+prespawn_amount = 2
+max_prespawn_offset = 5.0
 
 [node name="Soap" parent="Spawner" instance=ExtResource("3_sasra")]
 
@@ -108,6 +110,7 @@ move_interval = 0.8
 position = Vector2(656, 336)
 autostart = true
 object = NodePath("Person")
+prespawn_amount = 4
 
 [node name="Person" parent="Spawner2" instance=ExtResource("2_sasra")]
 
@@ -119,6 +122,7 @@ min_spawn_time = 2.0
 max_spawn_time = 4.0
 move_interval = 0.4
 move_direction = Vector2(1, 0)
+prespawn_amount = 4
 
 [node name="Person" parent="Spawner4" instance=ExtResource("2_sasra")]
 
@@ -129,6 +133,7 @@ object = NodePath("Bubbles")
 min_spawn_time = 2.0
 max_spawn_time = 5.0
 move_interval = 0.7
+prespawn_amount = 2
 
 [node name="Bubbles" parent="Spawner3" instance=ExtResource("8_rpuu0")]
 


### PR DESCRIPTION
Changes:
- Can spawn things on start (instead of waiting for timer)
- Can have pre spawned objects (lots of variables to adjust positioning and how many)